### PR TITLE
Add Kaggle dataset download notebook

### DIFF
--- a/notebooks/download_dataset.ipynb
+++ b/notebooks/download_dataset.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a2283cfb",
+   "metadata": {},
+   "source": [
+    "# Cafe Rewards Offer Dataset\n",
+    "This notebook downloads data from Kaggle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a572f555",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install kaggle --quiet"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79e84379",
+   "metadata": {},
+   "source": [
+    "Set up Kaggle API credentials. Upload your `kaggle.json` containing your Kaggle username and API key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e744636",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, json\n",
+    "from pathlib import Path\n",
+    "creds_path = Path('kaggle.json')\n",
+    "if creds_path.is_file():\n",
+    "    creds = json.loads(creds_path.read_text())\n",
+    "    os.environ['KAGGLE_USERNAME'] = creds['username']\n",
+    "    os.environ['KAGGLE_KEY'] = creds['key']\n",
+    "else:\n",
+    "    print('kaggle.json not found. Please upload it.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02fad891",
+   "metadata": {},
+   "source": [
+    "Download the dataset from Kaggle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b36afef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!kaggle datasets download arshmankhalid/caf-rewards-offer-dataset -p data --unzip --force"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aeedb242",
+   "metadata": {},
+   "source": [
+    "Load the customers.csv file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c69ae443",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "customers = pd.read_csv('data/customers.csv')\n",
+    "customers.head()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- create `download_dataset.ipynb` jupyter notebook for downloading the Cafe Rewards Offer dataset from Kaggle

## Testing
- `pytest -q`
- *(failure expected)* `/root/.pyenv/versions/3.11.12/bin/kaggle datasets download arshmankhalid/caf-rewards-offer-dataset -p data --unzip --force`

------
https://chatgpt.com/codex/tasks/task_e_6853ffde5b40832ca04e26977bc3a985